### PR TITLE
Add WiFi network management UI for Ableton Move

### DIFF
--- a/electron/backend.js
+++ b/electron/backend.js
@@ -2497,6 +2497,190 @@ async function testSshFormats(cookie) {
     return results;
 }
 
+// --- WiFi Management Helpers ---
+
+function parseServiceLine(line) {
+    if (!line || !line.trim()) return null;
+    // Flags are at fixed positions in the raw line (before trimming):
+    // pos 0: '*' (favorite/saved), pos 1: 'A' (auto-connect), pos 2: 'O'/'R' (state)
+    const flagChars = line.substring(0, 4);
+    const isSaved = flagChars[0] === '*';
+    const isAutoConnect = flagChars[1] === 'A';
+    const isReady = flagChars[2] === 'R';
+    const isOnline = flagChars[2] === 'O';
+    const rest = line.substring(4).trim();
+    // Service ID is always the last whitespace-delimited token starting with wifi_
+    const tokens = rest.split(/\s+/);
+    const serviceId = [...tokens].reverse().find(t => t.startsWith('wifi_'));
+    if (!serviceId) return null;
+    // Network name is everything before the service ID
+    const nameEnd = rest.lastIndexOf(serviceId);
+    const name = rest.substring(0, nameEnd).trim();
+    // Derive security from service ID suffix
+    let security = 'unknown';
+    if (serviceId.endsWith('_psk')) security = 'WPA';
+    else if (serviceId.endsWith('_wep')) security = 'WEP';
+    else if (serviceId.endsWith('_none')) security = 'open';
+    else if (serviceId.includes('_ieee8021x')) security = 'Enterprise';
+    return {
+        name: name || '(Hidden Network)',
+        serviceId,
+        security,
+        connected: isReady,
+        saved: isSaved,
+        online: isOnline,
+        ready: isReady
+    };
+}
+
+function parseServices(output) {
+    if (!output) return [];
+    return output.split('\n').map(parseServiceLine).filter(Boolean);
+}
+
+function extractSsidFromServiceId(serviceId) {
+    // Format: wifi_<mac>_<hexssid>_managed_<security>
+    const parts = serviceId.split('_');
+    // parts[0]=wifi, parts[1]=mac, parts[2]=hexssid, ...
+    if (parts.length < 3) return serviceId;
+    const hexSsid = parts[2];
+    try {
+        return Buffer.from(hexSsid, 'hex').toString('utf8');
+    } catch {
+        return hexSsid;
+    }
+}
+
+// --- WiFi Management Functions ---
+
+async function wifiGetStatus(hostname) {
+    const hostIp = cachedDeviceIp || hostname;
+    let wifiEnabled = false;
+    let connectedService = null;
+    const isUsbConnection = cachedDeviceIp ? /^192\.168\.7\./.test(cachedDeviceIp) : false;
+
+    try {
+        const techOutput = await sshExec(hostIp, 'connmanctl technologies');
+        // Check if WiFi technology is powered on
+        const wifiSection = techOutput.split('/net/connman/technology/wifi');
+        if (wifiSection.length > 1) {
+            const sectionText = wifiSection[1].split('/net/connman/technology/')[0] || wifiSection[1];
+            wifiEnabled = /Powered\s*=\s*True/i.test(sectionText);
+        }
+    } catch (err) {
+        console.log('[WIFI] Error checking technologies:', err.message);
+    }
+
+    try {
+        const servicesOutput = await sshExec(hostIp, 'connmanctl services');
+        const services = parseServices(servicesOutput);
+        connectedService = services.find(s => s.connected) || null;
+    } catch (err) {
+        console.log('[WIFI] Error listing services:', err.message);
+    }
+
+    return { wifiEnabled, connectedService, isUsbConnection };
+}
+
+async function wifiScan(hostname) {
+    const hostIp = cachedDeviceIp || hostname;
+    try {
+        await sshExec(hostIp, 'connmanctl scan wifi');
+    } catch (err) {
+        console.log('[WIFI] Scan command error (may be normal):', err.message);
+    }
+    // Wait for scan to complete
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    const servicesOutput = await sshExec(hostIp, 'connmanctl services');
+    return parseServices(servicesOutput);
+}
+
+async function wifiListServices(hostname) {
+    const hostIp = cachedDeviceIp || hostname;
+    const servicesOutput = await sshExec(hostIp, 'connmanctl services');
+    return parseServices(servicesOutput);
+}
+
+async function wifiConnect(hostname, serviceId, passphrase) {
+    const hostIp = cachedDeviceIp || hostname;
+    // Connman on the Move stores service data in /data/settings/connman/lib/connman/
+    const connmanDataDir = '/data/settings/connman/lib/connman';
+
+    if (passphrase) {
+        // Extract the hex SSID from the service ID (third underscore-delimited segment)
+        const parts = serviceId.split('_');
+        const hexSsid = parts.length >= 3 ? parts[2] : '';
+        const ssid = extractSsidFromServiceId(serviceId);
+
+        // Write a connman service settings file directly — same format as saved networks
+        const settingsDir = `${connmanDataDir}/${serviceId}`;
+        const settingsContent = `[${serviceId}]\\nName=${ssid}\\nSSID=${hexSsid}\\nFavorite=true\\nAutoConnect=true\\nPassphrase=${passphrase.replace(/\\/g, '\\\\').replace(/'/g, "'\\''")}\\nIPv4.method=dhcp\\nIPv6.method=auto\\nIPv6.privacy=disabled\\n`;
+
+        console.log('[WIFI] Writing service settings for:', ssid);
+        try {
+            await sshExec(hostIp, `mkdir -p ${settingsDir}`, { username: 'root' });
+            await sshExec(hostIp, `printf '${settingsContent}' > ${settingsDir}/settings`, { username: 'root' });
+        } catch (err) {
+            throw new Error(`Failed to write WiFi settings: ${err.message}`);
+        }
+
+        // Connman only reads settings from disk at startup — restart it to load credentials,
+        // then explicitly connect (otherwise it reconnects to the previous favorite).
+        try {
+            console.log('[WIFI] Restarting connman to pick up new credentials...');
+            await sshExec(hostIp, `/etc/init.d/connman restart`, { username: 'root' });
+        } catch (err) {
+            if (err.message && (err.message.includes('Timed out') || err.message.includes('ECONNRESET') || err.message.includes('Connection lost'))) {
+                console.log('[WIFI] SSH dropped during connman restart (expected)');
+            } else {
+                throw new Error(`Failed to restart connman: ${err.message}`);
+            }
+        }
+        // Wait for connman to come back and reconnect to WiFi
+        await new Promise(resolve => setTimeout(resolve, 5000));
+    }
+
+    // Connect to the target network (works for new, open, and saved networks)
+    try {
+        console.log('[WIFI] Connecting to:', serviceId);
+        await sshExec(hostIp, `nohup connmanctl connect ${serviceId} > /dev/null 2>&1 &`);
+    } catch (err) {
+        if (err.message && (err.message.includes('Timed out') || err.message.includes('ECONNRESET') || err.message.includes('Connection lost'))) {
+            console.log('[WIFI] SSH dropped during connect (expected when switching networks)');
+            return;
+        }
+        throw new Error(`Failed to connect: ${err.message}`);
+    }
+}
+
+async function wifiDisconnect(hostname, serviceId) {
+    const hostIp = cachedDeviceIp || hostname;
+    try {
+        await sshExec(hostIp, `nohup connmanctl disconnect ${serviceId} > /dev/null 2>&1 &`);
+    } catch (err) {
+        // SSH drop is expected when disconnecting the active WiFi network
+        if (err.message && (err.message.includes('Timed out') || err.message.includes('ECONNRESET') || err.message.includes('Connection lost'))) {
+            console.log('[WIFI] SSH dropped during disconnect (expected)');
+            return;
+        }
+        throw err;
+    }
+}
+
+async function wifiRemoveService(hostname, serviceId) {
+    const hostIp = cachedDeviceIp || hostname;
+    await sshExec(hostIp, `connmanctl config ${serviceId} --remove`);
+    // Also remove the service settings directory
+    try {
+        await sshExec(hostIp, `rm -rf /data/settings/connman/lib/connman/${serviceId}`, { username: 'root' });
+    } catch {}
+}
+
+async function wifiEnableRadio(hostname) {
+    const hostIp = cachedDeviceIp || hostname;
+    await sshExec(hostIp, 'connmanctl enable wifi', { username: 'root' });
+}
+
 module.exports = {
     setMainWindow,
     validateDevice,
@@ -2537,5 +2721,12 @@ module.exports = {
     cleanDeviceTmp,
     fixPermissions,
     checkInstallerUpdate,
-    clearDnsCache
+    clearDnsCache,
+    wifiGetStatus,
+    wifiScan,
+    wifiListServices,
+    wifiConnect,
+    wifiDisconnect,
+    wifiRemoveService,
+    wifiEnableRadio
 };

--- a/electron/main.js
+++ b/electron/main.js
@@ -255,6 +255,35 @@ ipcMain.handle('fix_permissions', async (event, { hostname }) => {
     return await backend.fixPermissions(hostname);
 });
 
+// --- WiFi Management ---
+ipcMain.handle('wifi_get_status', async (event, { hostname }) => {
+    return await backend.wifiGetStatus(hostname);
+});
+
+ipcMain.handle('wifi_scan', async (event, { hostname }) => {
+    return await backend.wifiScan(hostname);
+});
+
+ipcMain.handle('wifi_list_services', async (event, { hostname }) => {
+    return await backend.wifiListServices(hostname);
+});
+
+ipcMain.handle('wifi_connect', async (event, { hostname, serviceId, passphrase }) => {
+    return await backend.wifiConnect(hostname, serviceId, passphrase);
+});
+
+ipcMain.handle('wifi_disconnect', async (event, { hostname, serviceId }) => {
+    return await backend.wifiDisconnect(hostname, serviceId);
+});
+
+ipcMain.handle('wifi_remove_service', async (event, { hostname, serviceId }) => {
+    return await backend.wifiRemoveService(hostname, serviceId);
+});
+
+ipcMain.handle('wifi_enable_radio', async (event, { hostname }) => {
+    return await backend.wifiEnableRadio(hostname);
+});
+
 ipcMain.handle('export_logs', async (event, { logs }) => {
     const { filePath } = await dialog.showSaveDialog(mainWindow, {
         title: 'Save Debug Logs',

--- a/ui/app.js
+++ b/ui/app.js
@@ -832,6 +832,15 @@ const assetBrowser = {
     loading: false
 };
 
+// --- WiFi Manager State ---
+const wifiManager = {
+    open: false,
+    loading: false,
+    networks: [],
+    isUsbConnection: false,
+    passwordTarget: null
+};
+
 async function processModuleOpQueue() {
     if (moduleOpRunning || moduleOpQueue.length === 0) return;
     moduleOpRunning = true;
@@ -2200,6 +2209,274 @@ function closeApplication() {
     window.close();
 }
 
+// --- WiFi Manager Functions ---
+
+async function openWifiManager() {
+    wifiManager.open = true;
+    wifiManager.networks = [];
+    wifiManager.passwordTarget = null;
+    document.getElementById('wifi-modal').style.display = 'flex';
+    document.getElementById('wifi-network-view').style.display = '';
+    document.getElementById('wifi-password-view').style.display = 'none';
+    document.getElementById('wifi-disabled-view').style.display = 'none';
+    document.getElementById('wifi-warning').style.display = 'none';
+    document.getElementById('wifi-network-list').innerHTML = '';
+    setWifiStatus('Checking WiFi status...', '');
+
+    try {
+        const hostname = state.deviceIp;
+        const status = await window.installer.invoke('wifi_get_status', { hostname });
+        wifiManager.isUsbConnection = status.isUsbConnection;
+
+        if (!status.isUsbConnection) {
+            document.getElementById('wifi-warning').style.display = '';
+        }
+
+        if (!status.wifiEnabled) {
+            document.getElementById('wifi-network-view').style.display = 'none';
+            document.getElementById('wifi-disabled-view').style.display = '';
+            setWifiStatus('WiFi is disabled', 'disconnected');
+            return;
+        }
+
+        if (status.connectedService) {
+            setWifiStatus(`Connected to ${status.connectedService.name}`, 'connected');
+        } else {
+            setWifiStatus('Not connected', 'disconnected');
+        }
+
+        wifiDoScan();
+    } catch (err) {
+        setWifiStatus(`Error: ${err.message}`, 'error');
+    }
+}
+
+function closeWifiManager() {
+    wifiManager.open = false;
+    wifiManager.passwordTarget = null;
+    document.getElementById('wifi-modal').style.display = 'none';
+}
+
+function setWifiStatus(text, cssClass) {
+    const dot = document.getElementById('wifi-status-dot');
+    const textEl = document.getElementById('wifi-status-text');
+    dot.className = 'wifi-status-dot' + (cssClass ? ' ' + cssClass : '');
+    textEl.textContent = text;
+}
+
+async function wifiDoScan() {
+    const scanBtn = document.getElementById('wifi-scan-btn');
+    scanBtn.disabled = true;
+    scanBtn.textContent = 'Scanning...';
+    document.getElementById('wifi-status').textContent = 'Scanning for networks...';
+
+    try {
+        const hostname = state.deviceIp;
+        const networks = await window.installer.invoke('wifi_scan', { hostname });
+        wifiManager.networks = networks;
+        showWifiNetworkList(networks);
+        document.getElementById('wifi-status').textContent = `Found ${networks.length} network(s)`;
+        // Update status bar based on connected network
+        const connected = networks.find(n => n.connected);
+        if (connected) {
+            setWifiStatus(`Connected to ${connected.name}`, 'connected');
+        } else {
+            setWifiStatus('Not connected', 'disconnected');
+        }
+    } catch (err) {
+        document.getElementById('wifi-status').textContent = `Scan failed: ${err.message}`;
+        setWifiStatus('Error', 'error');
+    } finally {
+        scanBtn.disabled = false;
+        scanBtn.textContent = 'Scan for Networks';
+    }
+}
+
+function showWifiNetworkList(networks) {
+    const list = document.getElementById('wifi-network-list');
+    // Sort: connected first, then saved, then alphabetical
+    const sorted = [...networks].sort((a, b) => {
+        if (a.connected !== b.connected) return a.connected ? -1 : 1;
+        if (a.saved !== b.saved) return a.saved ? -1 : 1;
+        return a.name.localeCompare(b.name);
+    });
+
+    list.innerHTML = sorted.map(n => {
+        const icon = n.connected ? '&#10003;' : (n.security !== 'open' ? '&#128274;' : '&#8226;');
+        const details = [];
+        if (n.connected) details.push('Connected');
+        else if (n.saved) details.push('Saved');
+        if (n.security !== 'open') details.push(n.security);
+        else details.push('Open');
+
+        let actions = '';
+        if (n.connected) {
+            actions = `<button data-action="disconnect" data-service="${n.serviceId}">Disconnect</button>`;
+        } else if (n.security === 'Enterprise') {
+            actions = `<span style="color: #666; font-size: 0.75rem;">Enterprise</span>`;
+        } else if (n.name === '(Hidden Network)') {
+            actions = `<span style="color: #666; font-size: 0.75rem;">Hidden</span>`;
+        } else {
+            actions = `<button data-action="connect" data-service="${n.serviceId}" data-name="${n.name}" data-security="${n.security}" data-saved="${n.saved}">Connect</button>`;
+        }
+        if (n.saved && !n.connected) {
+            actions += `<button data-action="forget" data-service="${n.serviceId}" data-name="${n.name}">Forget</button>`;
+        }
+
+        return `<div class="wifi-network-entry${n.connected ? ' connected' : ''}">
+            <div class="wifi-network-icon">${icon}</div>
+            <div class="wifi-network-info">
+                <div class="wifi-network-name">${n.name}</div>
+                <div class="wifi-network-detail">${details.join(' \u00b7 ')}</div>
+            </div>
+            <div class="wifi-network-actions">${actions}</div>
+        </div>`;
+    }).join('');
+
+    // Attach event listeners
+    list.querySelectorAll('button[data-action]').forEach(btn => {
+        btn.onclick = () => {
+            const action = btn.dataset.action;
+            const serviceId = btn.dataset.service;
+            const name = btn.dataset.name;
+            const security = btn.dataset.security;
+            const saved = btn.dataset.saved === 'true';
+            if (action === 'connect') {
+                wifiConnectToNetwork({ serviceId, name, security, saved });
+            } else if (action === 'disconnect') {
+                wifiDisconnect({ serviceId, name });
+            } else if (action === 'forget') {
+                wifiForgetNetwork({ serviceId, name });
+            }
+        };
+    });
+}
+
+function wifiConnectToNetwork(network) {
+    if (!wifiManager.isUsbConnection) {
+        if (!confirm('You appear to be connected via WiFi. Changing networks may disconnect this session. Continue?')) {
+            return;
+        }
+    }
+    // If secured and not saved, show password form
+    if (network.security !== 'open' && !network.saved) {
+        wifiManager.passwordTarget = network;
+        document.getElementById('wifi-password-network-name').textContent = network.name;
+        document.getElementById('wifi-password-input').value = '';
+        document.getElementById('wifi-network-view').style.display = 'none';
+        document.getElementById('wifi-password-view').style.display = '';
+        setTimeout(() => document.getElementById('wifi-password-input').focus(), 100);
+        return;
+    }
+    wifiDoConnect(network.serviceId, null, network.name);
+}
+
+async function wifiDoConnect(serviceId, passphrase, name) {
+    document.getElementById('wifi-status').textContent = `Connecting to ${name}...`;
+    try {
+        const hostname = state.deviceIp;
+        await window.installer.invoke('wifi_connect', { hostname, serviceId, passphrase });
+        document.getElementById('wifi-status').textContent = `Connected to ${name}`;
+        setWifiStatus(`Connected to ${name}`, 'connected');
+    } catch (err) {
+        document.getElementById('wifi-status').textContent = `Connection failed: ${err.message}`;
+        setWifiStatus('Connection failed', 'error');
+    }
+    // Refresh list after delay (SSH may have dropped and reconnected)
+    setTimeout(async () => {
+        try {
+            const hostname = state.deviceIp;
+            const networks = await window.installer.invoke('wifi_list_services', { hostname });
+            wifiManager.networks = networks;
+            showWifiNetworkList(networks);
+            const connected = networks.find(n => n.connected);
+            if (connected) {
+                setWifiStatus(`Connected to ${connected.name}`, 'connected');
+            }
+        } catch (err) {
+            document.getElementById('wifi-status').textContent = 'Could not refresh — SSH session may have dropped. Close and reopen WiFi to retry.';
+        }
+    }, 2000);
+}
+
+function wifiPasswordSubmit() {
+    const passphrase = document.getElementById('wifi-password-input').value;
+    if (!passphrase) return;
+    const target = wifiManager.passwordTarget;
+    wifiManager.passwordTarget = null;
+    document.getElementById('wifi-password-view').style.display = 'none';
+    document.getElementById('wifi-network-view').style.display = '';
+    wifiDoConnect(target.serviceId, passphrase, target.name);
+}
+
+function wifiPasswordCancel() {
+    wifiManager.passwordTarget = null;
+    document.getElementById('wifi-password-view').style.display = 'none';
+    document.getElementById('wifi-network-view').style.display = '';
+}
+
+async function wifiDisconnect(network) {
+    if (!wifiManager.isUsbConnection) {
+        if (!confirm('You appear to be connected via WiFi. Disconnecting may drop this session. Continue?')) {
+            return;
+        }
+    }
+    document.getElementById('wifi-status').textContent = `Disconnecting from ${network.name || 'network'}...`;
+    try {
+        const hostname = state.deviceIp;
+        await window.installer.invoke('wifi_disconnect', { hostname, serviceId: network.serviceId });
+        document.getElementById('wifi-status').textContent = 'Disconnected';
+        setWifiStatus('Not connected', 'disconnected');
+    } catch (err) {
+        document.getElementById('wifi-status').textContent = `Disconnect failed: ${err.message}`;
+    }
+    setTimeout(async () => {
+        try {
+            const hostname = state.deviceIp;
+            const networks = await window.installer.invoke('wifi_list_services', { hostname });
+            wifiManager.networks = networks;
+            showWifiNetworkList(networks);
+        } catch {}
+    }, 1500);
+}
+
+async function wifiForgetNetwork(network) {
+    if (!confirm(`Forget "${network.name}"? You will need to re-enter the password to connect again.`)) return;
+    document.getElementById('wifi-status').textContent = `Removing ${network.name}...`;
+    try {
+        const hostname = state.deviceIp;
+        await window.installer.invoke('wifi_remove_service', { hostname, serviceId: network.serviceId });
+        document.getElementById('wifi-status').textContent = `Removed ${network.name}`;
+    } catch (err) {
+        document.getElementById('wifi-status').textContent = `Remove failed: ${err.message}`;
+    }
+    try {
+        const hostname = state.deviceIp;
+        const networks = await window.installer.invoke('wifi_list_services', { hostname });
+        wifiManager.networks = networks;
+        showWifiNetworkList(networks);
+    } catch {}
+}
+
+async function wifiEnableRadio() {
+    const btn = document.getElementById('wifi-enable-btn');
+    btn.disabled = true;
+    btn.textContent = 'Enabling...';
+    try {
+        const hostname = state.deviceIp;
+        await window.installer.invoke('wifi_enable_radio', { hostname });
+        document.getElementById('wifi-disabled-view').style.display = 'none';
+        document.getElementById('wifi-network-view').style.display = '';
+        setWifiStatus('WiFi enabled', 'disconnected');
+        wifiDoScan();
+    } catch (err) {
+        document.getElementById('wifi-status').textContent = `Failed to enable WiFi: ${err.message}`;
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Enable WiFi';
+    }
+}
+
 // Event Listeners
 document.addEventListener('DOMContentLoaded', async () => {
     console.log('[DEBUG] DOM loaded, installer API available:', !!window.installer);
@@ -2637,7 +2914,27 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Close modal on Escape key
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && assetBrowser.open) closeAssetBrowser();
+        if (e.key === 'Escape') {
+            if (wifiManager.open) closeWifiManager();
+            else if (assetBrowser.open) closeAssetBrowser();
+        }
+    });
+
+    // WiFi manager events
+    document.getElementById('link-wifi').onclick = (e) => {
+        e.preventDefault();
+        openWifiManager();
+    };
+    document.getElementById('wifi-modal-close').onclick = closeWifiManager;
+    document.getElementById('wifi-scan-btn').onclick = wifiDoScan;
+    document.getElementById('wifi-enable-btn').onclick = wifiEnableRadio;
+    document.getElementById('wifi-password-connect').onclick = wifiPasswordSubmit;
+    document.getElementById('wifi-password-cancel').onclick = wifiPasswordCancel;
+    document.getElementById('wifi-modal').onclick = (e) => {
+        if (e.target.id === 'wifi-modal') closeWifiManager();
+    };
+    document.getElementById('wifi-password-input').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') wifiPasswordSubmit();
     });
 
     // Drag-and-drop on asset browser dropzone

--- a/ui/index.html
+++ b/ui/index.html
@@ -187,6 +187,8 @@
                 <span class="secondary-divider">|</span>
                 <a href="#" id="link-standalone">Standalone Mode</a>
                 <span class="secondary-divider">|</span>
+                <a href="#" id="link-wifi">WiFi</a>
+                <span class="secondary-divider">|</span>
                 <a href="#" id="link-uninstall">Uninstall</a>
             </div>
         </div>
@@ -245,6 +247,45 @@
                     </div>
                 </div>
                 <div id="asset-browser-status" class="asset-status"></div>
+            </div>
+        </div>
+        <!-- WiFi Manager Modal -->
+        <div id="wifi-modal" class="modal-overlay" style="display: none;">
+            <div class="modal-content wifi-modal-content">
+                <div class="modal-header">
+                    <h2>WiFi Networks</h2>
+                    <button id="wifi-modal-close" class="modal-close-btn">&times;</button>
+                </div>
+                <div id="wifi-warning" class="wifi-warning" style="display: none;">
+                    You appear to be connected via WiFi. Changing networks will disconnect this session.
+                </div>
+                <div id="wifi-status-bar" class="wifi-status-bar">
+                    <span id="wifi-status-dot" class="wifi-status-dot"></span>
+                    <span id="wifi-status-text">Checking...</span>
+                </div>
+                <div id="wifi-disabled-view" style="display: none;">
+                    <div class="wifi-disabled-message">
+                        <p>WiFi radio is currently disabled on your Move.</p>
+                        <button id="wifi-enable-btn" class="btn-action">Enable WiFi</button>
+                    </div>
+                </div>
+                <div id="wifi-network-view">
+                    <div class="wifi-toolbar">
+                        <button id="wifi-scan-btn" class="btn-action">Scan for Networks</button>
+                    </div>
+                    <div id="wifi-network-list" class="wifi-network-list"></div>
+                </div>
+                <div id="wifi-password-view" style="display: none;">
+                    <div class="wifi-password-form">
+                        <p id="wifi-password-label">Enter password for <strong id="wifi-password-network-name"></strong></p>
+                        <input type="password" id="wifi-password-input" placeholder="WiFi password" autocomplete="off" />
+                        <div class="wifi-password-actions">
+                            <button id="wifi-password-cancel" class="secondary">Cancel</button>
+                            <button id="wifi-password-connect" class="btn-action">Connect</button>
+                        </div>
+                    </div>
+                </div>
+                <div id="wifi-status" class="asset-status"></div>
             </div>
         </div>
     </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1315,3 +1315,180 @@ button.secondary:hover {
 .btn-reenable:hover {
     background: #e0aa44;
 }
+
+/* WiFi Manager Modal */
+.wifi-modal-content {
+    max-width: 480px;
+}
+
+.wifi-warning {
+    background: #3a2a00;
+    border-bottom: 1px solid #665500;
+    color: #ffcc44;
+    padding: 0.6rem 1.25rem;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.wifi-status-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.25rem;
+    border-bottom: 1px solid #333;
+    font-size: 0.85rem;
+    color: #aaa;
+}
+
+.wifi-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #666;
+    flex-shrink: 0;
+}
+
+.wifi-status-dot.connected {
+    background: #44aa44;
+}
+
+.wifi-status-dot.disconnected {
+    background: #666;
+}
+
+.wifi-status-dot.error {
+    background: #cc4444;
+}
+
+.wifi-toolbar {
+    padding: 0.5rem 1.25rem;
+}
+
+.wifi-disabled-message {
+    text-align: center;
+    padding: 2rem 1.25rem;
+    color: #aaa;
+}
+
+.wifi-disabled-message p {
+    margin-bottom: 1rem;
+}
+
+.wifi-network-list {
+    overflow-y: auto;
+    max-height: 350px;
+    margin: 0 1.25rem;
+}
+
+.wifi-network-entry {
+    display: flex;
+    align-items: center;
+    padding: 0.6rem 0.5rem;
+    border-bottom: 1px solid #2a2a2a;
+    gap: 0.5rem;
+}
+
+.wifi-network-entry:last-child {
+    border-bottom: none;
+}
+
+.wifi-network-entry:hover {
+    background: #252525;
+}
+
+.wifi-network-icon {
+    width: 20px;
+    text-align: center;
+    flex-shrink: 0;
+    font-size: 0.8rem;
+    color: #888;
+}
+
+.wifi-network-entry.connected .wifi-network-icon {
+    color: #44aa44;
+}
+
+.wifi-network-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.wifi-network-name {
+    color: #ccc;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wifi-network-entry.connected .wifi-network-name {
+    color: #44cc44;
+}
+
+.wifi-network-detail {
+    color: #666;
+    font-size: 0.75rem;
+    margin-top: 1px;
+}
+
+.wifi-network-actions {
+    display: flex;
+    gap: 0.3rem;
+    flex-shrink: 0;
+}
+
+.wifi-network-actions button {
+    background: none;
+    border: 1px solid #444;
+    color: #aaa;
+    padding: 0.25rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    width: auto;
+    margin: 0;
+}
+
+.wifi-network-actions button:hover {
+    border-color: #666;
+    color: #fff;
+    background: #333;
+}
+
+.wifi-password-form {
+    padding: 1.25rem;
+}
+
+.wifi-password-form p {
+    margin-bottom: 0.75rem;
+    color: #ccc;
+    font-size: 0.9rem;
+}
+
+.wifi-password-form input {
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 6px;
+    color: #e0e0e0;
+    font-size: 0.9rem;
+    margin-bottom: 0.75rem;
+}
+
+.wifi-password-form input:focus {
+    outline: none;
+    border-color: #0066cc;
+}
+
+.wifi-password-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
+.wifi-password-actions button {
+    width: auto;
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary

The Move's letter matrix for entering WiFi passwords is unfortunately not accessible to blind screenreader users such as myself, and is also tedious to use for sighted individuals especially when having to enter long and complicated WiFi passwords.
This PR addresses this in the following ways:

- Adds a "WiFi" link in management mode that opens a modal for managing WiFi networks on the Move
- Users can scan, connect (open/WPA), disconnect, and forget networks without manual SSH access
- Detects USB vs WiFi connection and warns users that switching networks over WiFi will drop the session

## Implementation notes

The Move runs connman for network management. Key details:

- **Scanning/listing**: Parses `connmanctl services` output with fixed-position flag extraction (flags are at byte offsets 0-3 in the raw line)
- **Connecting to new WPA networks**: Writes credentials to connman's service settings directory (`/data/settings/connman/lib/connman/<serviceId>/settings`), restarts connman via `/etc/init.d/connman restart` to load them, then issues `connmanctl connect`
- **SSH resilience**: Connect/disconnect commands are backgrounded with `nohup` since switching the active WiFi network drops the SSH session. The frontend retries after a delay to pick up the new state
- **USB detection**: `192.168.7.x` = USB gadget networking; other IPs assumed to be WiFi

## Test plan

- [ ] Connect to Move over WiFi, open WiFi modal — warning banner should appear
- [ ] Connect to Move over USB, open WiFi modal — no warning banner
- [ ] Scan for networks — list populates after ~3s
- [ ] Connect to a WPA network — password prompt shown, connects after entry
- [ ] Connect to an open network — connects without password prompt
- [ ] Connect to a saved network — connects without password prompt
- [ ] Disconnect from connected network
- [ ] Forget a saved network
- [ ] Test with WiFi radio disabled — shows enable button
