### PR TITLE
fix: macOS Local Network Privacy prompt never triggers

### DIFF
--- a/electron/backend.js
+++ b/electron/backend.js
@@ -21,8 +21,16 @@ const cookieStore = path.join(os.homedir(), '.schwung-installer-cookie');
 // Store reference to main window for logging
 let mainWindowForLogging = null;
 
+// Electron's net module (set from main.js) — uses Chromium's network stack,
+// which properly integrates with macOS Local Network Privacy prompts.
+let electronNet = null;
+
 function setMainWindow(win) {
     mainWindowForLogging = win;
+}
+
+function setElectronNet(net) {
+    electronNet = net;
 }
 
 // Override console.log to also send to renderer
@@ -196,24 +204,116 @@ async function validateDevice(baseUrl) {
                             throw new Error('All Windows resolution methods failed');
                         }
                     } else {
-                            // macOS/Linux: Use system resolver to get IPv4
-                            const { stdout } = await new Promise((resolve, reject) => {
-                                const cmd = process.platform === 'darwin'
-                                    ? `dscacheutil -q host -a name ${hostname} | grep ip_address | head -1 | awk '{print $2}'`
-                                    : `getent ahostsv4 ${hostname} | head -1 | awk '{print $1}'`;
+                            // macOS/Linux: Try multiple resolution methods
+                            const { exec: execCb } = require('child_process');
+                            const execAsync = require('util').promisify(execCb);
 
-                                require('child_process').exec(cmd, (err, stdout, stderr) => {
-                                    if (err) reject(err);
-                                    else resolve({ stdout });
-                                });
-                            });
+                            const resolvers = [];
 
-                            const ip = stdout.trim();
-                            if (ip && /^\d+\.\d+\.\d+\.\d+$/.test(ip)) {
-                                cachedDeviceIp = ip;
-                                console.log(`[DEBUG] Resolved ${hostname} to ${cachedDeviceIp} (IPv4)`);
+                            if (process.platform === 'darwin') {
+                                resolvers.push(
+                                    {
+                                        name: 'dns.lookup',
+                                        fn: async () => {
+                                            return new Promise((resolve, reject) => {
+                                                const timer = setTimeout(() => reject(new Error('dns.lookup timed out')), 5000);
+                                                dns.lookup(hostname, { family: 4 }, (err, address) => {
+                                                    clearTimeout(timer);
+                                                    if (err) reject(err);
+                                                    else resolve(address);
+                                                });
+                                            });
+                                        }
+                                    },
+                                    {
+                                        name: 'dscacheutil',
+                                        fn: async () => {
+                                            const { stdout } = await execAsync(
+                                                `dscacheutil -q host -a name ${hostname} | grep ip_address | head -1 | awk '{print $2}'`,
+                                                { timeout: 5000 }
+                                            );
+                                            const ip = stdout.trim();
+                                            if (!ip || !/^\d+\.\d+\.\d+\.\d+$/.test(ip)) throw new Error('No IPv4 from dscacheutil');
+                                            return ip;
+                                        }
+                                    },
+                                    {
+                                        name: 'dns-sd',
+                                        fn: async () => {
+                                            const { spawn } = require('child_process');
+                                            return new Promise((resolve, reject) => {
+                                                const proc = spawn('dns-sd', ['-G', 'v4', hostname]);
+                                                let output = '';
+                                                const timeout = setTimeout(() => {
+                                                    proc.kill();
+                                                    reject(new Error('dns-sd timed out'));
+                                                }, 5000);
+                                                proc.stdout.on('data', (data) => {
+                                                    output += data.toString();
+                                                    const ipMatch = output.match(/\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})[\s\r\n]/);
+                                                    if (ipMatch) {
+                                                        clearTimeout(timeout);
+                                                        proc.kill();
+                                                        resolve(ipMatch[1]);
+                                                    }
+                                                });
+                                                proc.on('error', (err) => {
+                                                    clearTimeout(timeout);
+                                                    reject(err);
+                                                });
+                                            });
+                                        }
+                                    }
+                                );
                             } else {
-                                throw new Error('No IPv4 address found');
+                                // Linux
+                                resolvers.push(
+                                    {
+                                        name: 'dns.lookup',
+                                        fn: async () => {
+                                            return new Promise((resolve, reject) => {
+                                                const timer = setTimeout(() => reject(new Error('dns.lookup timed out')), 5000);
+                                                dns.lookup(hostname, { family: 4 }, (err, address) => {
+                                                    clearTimeout(timer);
+                                                    if (err) reject(err);
+                                                    else resolve(address);
+                                                });
+                                            });
+                                        }
+                                    },
+                                    {
+                                        name: 'getent',
+                                        fn: async () => {
+                                            const { stdout } = await execAsync(
+                                                `getent ahostsv4 ${hostname} | head -1 | awk '{print $1}'`,
+                                                { timeout: 5000 }
+                                            );
+                                            const ip = stdout.trim();
+                                            if (!ip || !/^\d+\.\d+\.\d+\.\d+$/.test(ip)) throw new Error('No IPv4 from getent');
+                                            return ip;
+                                        }
+                                    }
+                                );
+                            }
+
+                            let resolved = false;
+                            for (const resolver of resolvers) {
+                                try {
+                                    console.log(`[DEBUG] ${process.platform}: Trying ${resolver.name} to resolve ${hostname}...`);
+                                    const ip = await resolver.fn();
+                                    if (ip) {
+                                        cachedDeviceIp = ip;
+                                        console.log(`[DEBUG] Resolved ${hostname} to ${cachedDeviceIp} via ${resolver.name}`);
+                                        resolved = true;
+                                        break;
+                                    }
+                                } catch (resolverErr) {
+                                    console.log(`[DEBUG] ${resolver.name} failed: ${resolverErr.message}`);
+                                }
+                            }
+
+                            if (!resolved) {
+                                throw new Error(`All ${process.platform} resolution methods failed`);
                             }
                         }
                 } catch (err) {
@@ -233,39 +333,98 @@ async function validateDevice(baseUrl) {
             if (!cachedDeviceIp && hostname.endsWith('.local')) {
                 console.log(`[DEBUG] Attempting to get IP from HTTP connection...`);
 
-                // Use Node's http module directly to access socket info
-                const http = require('http');
-                const connectedIp = await new Promise((resolve, reject) => {
-                    const req = http.get(validateUrl, { timeout: 10000 }, (res) => {
-                        const socketIp = res.socket.remoteAddress;
-                        console.log(`[DEBUG] HTTP connected to IP: ${socketIp}`);
-                        resolve(socketIp);
-                        res.resume(); // Consume response
+                if (electronNet && process.platform === 'darwin') {
+                    // Use Electron net on macOS (triggers LNP prompt)
+                    console.log(`[DEBUG] Using Electron net for .local resolution (macOS LNP)`);
+                    await new Promise((resolve, reject) => {
+                        const request = electronNet.request({
+                            method: 'GET',
+                            url: validateUrl,
+                        });
+                        const timer = setTimeout(() => {
+                            request.abort();
+                            reject(new Error('Electron net request timeout'));
+                        }, 10000);
+                        request.on('response', (response) => {
+                            console.log(`[DEBUG] HTTP validation successful (status: ${response.statusCode})`);
+                            clearTimeout(timer);
+                            response.on('data', () => {}); // consume
+                            response.on('end', () => resolve());
+                        });
+                        request.on('error', (err) => {
+                            clearTimeout(timer);
+                            reject(err);
+                        });
+                        request.end();
                     });
-                    req.on('error', reject);
-                    req.on('timeout', () => reject(new Error('HTTP connection timeout')));
-                });
+                    // We validated but couldn't extract IP from Electron net —
+                    // the DNS resolvers above should have cached it already.
+                    // If not, subsequent operations will use the hostname directly.
+                } else {
+                    // Use Node's http module directly to access socket info
+                    const http = require('http');
+                    const connectedIp = await new Promise((resolve, reject) => {
+                        const req = http.get(validateUrl, { timeout: 10000 }, (res) => {
+                            const socketIp = res.socket.remoteAddress;
+                            console.log(`[DEBUG] HTTP connected to IP: ${socketIp}`);
+                            resolve(socketIp);
+                            res.resume(); // Consume response
+                        });
+                        req.on('error', reject);
+                        req.on('timeout', () => reject(new Error('HTTP connection timeout')));
+                    });
 
-                if (connectedIp) {
-                    // Clean up IPv6 formatting if needed (remove ::ffff: prefix)
-                    let cleanIp = connectedIp.replace(/^::ffff:/, '');
-                    cachedDeviceIp = cleanIp;
-                    console.log(`[DEBUG] Cached IP from HTTP connection: ${cachedDeviceIp}`);
+                    if (connectedIp) {
+                        // Clean up IPv6 formatting if needed (remove ::ffff: prefix)
+                        let cleanIp = connectedIp.replace(/^::ffff:/, '');
+                        cachedDeviceIp = cleanIp;
+                        console.log(`[DEBUG] Cached IP from HTTP connection: ${cachedDeviceIp}`);
+                    }
                 }
+            } else if (electronNet && process.platform === 'darwin') {
+                // Use Electron's net module on macOS — it uses Chromium's network stack
+                // which properly triggers the Local Network Privacy permission prompt.
+                // Node.js http/axios bypass Apple's Network framework and the prompt
+                // never appears, silently blocking local network connections.
+                console.log(`[DEBUG] Using Electron net module for macOS LNP compatibility`);
+                await new Promise((resolve, reject) => {
+                    const request = electronNet.request({
+                        method: 'GET',
+                        url: validateUrl,
+                    });
+                    const timer = setTimeout(() => {
+                        request.abort();
+                        reject(new Error('Electron net request timeout'));
+                    }, 10000);
+                    request.on('response', (response) => {
+                        console.log(`[DEBUG] HTTP validation successful (status: ${response.statusCode})`);
+                        clearTimeout(timer);
+                        response.on('data', () => {}); // consume
+                        response.on('end', () => resolve());
+                    });
+                    request.on('error', (err) => {
+                        clearTimeout(timer);
+                        reject(err);
+                    });
+                    request.end();
+                });
             } else {
-                // Just validate normally
+                // Just validate normally (non-macOS or no electron net available)
                 const response = await httpClient.get(validateUrl, { timeout: 10000 });
-                console.log(`[DEBUG] HTTP validation successful`);
+                console.log(`[DEBUG] HTTP validation successful (status: ${response.status})`);
             }
 
             return true;
         } catch (err) {
-            console.log(`[DEBUG] HTTP validation failed: ${err.message}`);
-            return false;
+            const errCode = err.code || 'unknown';
+            const errMsg = err.message || 'unknown error';
+            console.log(`[DEBUG] HTTP validation failed: ${errMsg} (code: ${errCode})`);
+            if (err.cause) console.log(`[DEBUG] HTTP validation cause: ${err.cause.message || err.cause}`);
+            return { valid: false, error: `Connection failed: ${errCode === 'unknown' ? errMsg : errCode}` };
         }
     } catch (err) {
         console.error('Device validation error:', err.message);
-        return false;
+        return { valid: false, error: err.message };
     }
 }
 
@@ -2872,6 +3031,7 @@ async function wifiEnableRadio(hostname) {
 
 module.exports = {
     setMainWindow,
+    setElectronNet,
     validateDevice,
     getSavedCookie,
     clearSavedCookie,

--- a/electron/backend.js
+++ b/electron/backend.js
@@ -33,6 +33,27 @@ function setElectronNet(net) {
     electronNet = net;
 }
 
+function electronNetGet(url, timeoutMs = 10000) {
+    return new Promise((resolve, reject) => {
+        const request = electronNet.request({ method: 'GET', url });
+        const timer = setTimeout(() => {
+            request.abort();
+            reject(new Error('Electron net request timeout'));
+        }, timeoutMs);
+        request.on('response', (response) => {
+            console.log(`[DEBUG] HTTP validation successful (status: ${response.statusCode})`);
+            clearTimeout(timer);
+            response.on('data', () => {}); // consume
+            response.on('end', () => resolve(response));
+        });
+        request.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+        request.end();
+    });
+}
+
 // Override console.log to also send to renderer
 const originalLog = console.log;
 console.log = function(...args) {
@@ -82,6 +103,11 @@ async function validateDevice(baseUrl) {
         // Extract hostname from baseUrl
         const url = new URL(baseUrl);
         const hostname = url.hostname;
+
+        // Sanitize hostname to prevent command injection in shell-based resolvers
+        if (!/^[a-zA-Z0-9._-]+$/.test(hostname)) {
+            return { valid: false, error: 'Invalid hostname' };
+        }
 
         // Check if hostname is already an IP address
         const isIpAddress = /^\d+\.\d+\.\d+\.\d+$/.test(hostname);
@@ -162,14 +188,16 @@ async function validateDevice(baseUrl) {
                                     return new Promise((resolve, reject) => {
                                         const proc = spawn('dns-sd', ['-G', 'v4', hostname]);
                                         let output = '';
+                                        let settled = false;
                                         const timeout = setTimeout(() => {
                                             proc.kill();
-                                            reject(new Error('dns-sd timed out'));
+                                            if (!settled) { settled = true; reject(new Error('dns-sd timed out')); }
                                         }, 5000);
                                         proc.stdout.on('data', (data) => {
                                             output += data.toString();
                                             const ipMatch = output.match(/\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})[\s\r\n]/);
-                                            if (ipMatch) {
+                                            if (ipMatch && !settled) {
+                                                settled = true;
                                                 clearTimeout(timeout);
                                                 proc.kill();
                                                 resolve(ipMatch[1]);
@@ -177,7 +205,11 @@ async function validateDevice(baseUrl) {
                                         });
                                         proc.on('error', (err) => {
                                             clearTimeout(timeout);
-                                            reject(err);
+                                            if (!settled) { settled = true; reject(err); }
+                                        });
+                                        proc.on('close', (code) => {
+                                            clearTimeout(timeout);
+                                            if (!settled) { settled = true; reject(new Error(`dns-sd exited (code ${code}) without result`)); }
                                         });
                                     });
                                 }
@@ -244,14 +276,16 @@ async function validateDevice(baseUrl) {
                                             return new Promise((resolve, reject) => {
                                                 const proc = spawn('dns-sd', ['-G', 'v4', hostname]);
                                                 let output = '';
+                                                let settled = false;
                                                 const timeout = setTimeout(() => {
                                                     proc.kill();
-                                                    reject(new Error('dns-sd timed out'));
+                                                    if (!settled) { settled = true; reject(new Error('dns-sd timed out')); }
                                                 }, 5000);
                                                 proc.stdout.on('data', (data) => {
                                                     output += data.toString();
                                                     const ipMatch = output.match(/\s(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})[\s\r\n]/);
-                                                    if (ipMatch) {
+                                                    if (ipMatch && !settled) {
+                                                        settled = true;
                                                         clearTimeout(timeout);
                                                         proc.kill();
                                                         resolve(ipMatch[1]);
@@ -259,7 +293,11 @@ async function validateDevice(baseUrl) {
                                                 });
                                                 proc.on('error', (err) => {
                                                     clearTimeout(timeout);
-                                                    reject(err);
+                                                    if (!settled) { settled = true; reject(err); }
+                                                });
+                                                proc.on('close', (code) => {
+                                                    clearTimeout(timeout);
+                                                    if (!settled) { settled = true; reject(new Error(`dns-sd exited (code ${code}) without result`)); }
                                                 });
                                             });
                                         }
@@ -336,27 +374,7 @@ async function validateDevice(baseUrl) {
                 if (electronNet && process.platform === 'darwin') {
                     // Use Electron net on macOS (triggers LNP prompt)
                     console.log(`[DEBUG] Using Electron net for .local resolution (macOS LNP)`);
-                    await new Promise((resolve, reject) => {
-                        const request = electronNet.request({
-                            method: 'GET',
-                            url: validateUrl,
-                        });
-                        const timer = setTimeout(() => {
-                            request.abort();
-                            reject(new Error('Electron net request timeout'));
-                        }, 10000);
-                        request.on('response', (response) => {
-                            console.log(`[DEBUG] HTTP validation successful (status: ${response.statusCode})`);
-                            clearTimeout(timer);
-                            response.on('data', () => {}); // consume
-                            response.on('end', () => resolve());
-                        });
-                        request.on('error', (err) => {
-                            clearTimeout(timer);
-                            reject(err);
-                        });
-                        request.end();
-                    });
+                    await electronNetGet(validateUrl);
                     // We validated but couldn't extract IP from Electron net —
                     // the DNS resolvers above should have cached it already.
                     // If not, subsequent operations will use the hostname directly.
@@ -387,27 +405,7 @@ async function validateDevice(baseUrl) {
                 // Node.js http/axios bypass Apple's Network framework and the prompt
                 // never appears, silently blocking local network connections.
                 console.log(`[DEBUG] Using Electron net module for macOS LNP compatibility`);
-                await new Promise((resolve, reject) => {
-                    const request = electronNet.request({
-                        method: 'GET',
-                        url: validateUrl,
-                    });
-                    const timer = setTimeout(() => {
-                        request.abort();
-                        reject(new Error('Electron net request timeout'));
-                    }, 10000);
-                    request.on('response', (response) => {
-                        console.log(`[DEBUG] HTTP validation successful (status: ${response.statusCode})`);
-                        clearTimeout(timer);
-                        response.on('data', () => {}); // consume
-                        response.on('end', () => resolve());
-                    });
-                    request.on('error', (err) => {
-                        clearTimeout(timer);
-                        reject(err);
-                    });
-                    request.end();
-                });
+                await electronNetGet(validateUrl);
             } else {
                 // Just validate normally (non-macOS or no electron net available)
                 const response = await httpClient.get(validateUrl, { timeout: 10000 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell, net } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const backend = require('./backend');
@@ -46,6 +46,10 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+    // Pass Electron's net module to backend — uses Chromium's network stack
+    // which properly triggers macOS Local Network Privacy prompts
+    backend.setElectronNet(net);
+
     createWindow();
 
     app.on('activate', () => {

--- a/ui/app.js
+++ b/ui/app.js
@@ -107,7 +107,8 @@ async function startDeviceDiscovery() {
     // Try configured hostname directly
     try {
         const baseUrl = `http://${state.hostname}`;
-        const isValid = await window.installer.invoke('validate_device_at', { baseUrl });
+        const result = await window.installer.invoke('validate_device_at', { baseUrl });
+        const isValid = result === true || (result && result.valid !== false);
 
         if (isValid) {
             console.log('[DEBUG]', state.hostname, 'validated successfully');
@@ -119,13 +120,24 @@ async function startDeviceDiscovery() {
             }, 500);
             return;
         }
+
+        // Extract error detail if available
+        const errorDetail = (result && result.error) ? result.error : '';
+        if (errorDetail) {
+            console.error('[DEBUG]', state.hostname, 'validation failed:', errorDetail);
+        }
     } catch (error) {
         console.error('[DEBUG]', state.hostname, 'validation failed:', error);
     }
 
     // If hostname fails, show retry button and manual entry
+    const isMac = navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
+    const lnpHint = isMac
+        ? `<p style="font-size: 0.85em; color: #888;">On macOS, check System Settings &gt; Privacy &amp; Security &gt; Local Network and make sure Schwung Installer is allowed.</p>`
+        : '';
     statusDiv.innerHTML = `<p style="color: orange;">Could not connect to ${state.hostname}</p>` +
         `<p>Make sure your Move is powered on and connected to the same WiFi network, then try again.</p>` +
+        lnpHint +
         `<button id="btn-retry-discovery" style="margin: 0.5rem 0;">Retry</button>` +
         `<p style="margin-top: 0.5rem;">Or enter your Move\'s IP address below:</p>`;
     document.getElementById('btn-retry-discovery').onclick = () => startDeviceDiscovery();
@@ -166,7 +178,8 @@ async function selectDevice(hostname) {
     try {
         // Validate device is reachable
         const baseUrl = `http://${hostname}`;
-        const isValid = await window.installer.invoke('validate_device_at', { baseUrl });
+        const result = await window.installer.invoke('validate_device_at', { baseUrl });
+        const isValid = result === true || (result && result.valid !== false);
 
         if (isValid) {
             console.log('[DEBUG] Device validated, checking for saved cookie...');
@@ -198,7 +211,14 @@ async function selectDevice(hostname) {
                 setupCodeEntry();
             }
         } else {
-            statusDiv.innerHTML = '<p style="color: red;">Not a valid Move device</p>';
+            const errorDetail = (result && result.error) ? `: ${result.error}` : '';
+            const isMac = navigator.platform.startsWith('Mac') || navigator.userAgent.includes('Macintosh');
+            const lnpHint = isMac
+                ? `<p style="font-size: 0.85em; color: #888;">On macOS, check System Settings &gt; Privacy &amp; Security &gt; Local Network and make sure Schwung Installer is allowed.</p>`
+                : '';
+            statusDiv.innerHTML = `<p style="color: red;">Could not reach Move device${errorDetail}</p>` +
+                `<p style="font-size: 0.85em; color: #888;">Check that your Move is on the same network and try again.</p>` +
+                lnpHint;
             document.querySelector('.manual-entry').style.display = 'block';
         }
     } catch (error) {


### PR DESCRIPTION
## Summary

- On macOS, the packaged app launched from Finder never triggers the Local Network Privacy permission prompt — connections to the Move device silently fail
- Root cause: Node.js HTTP (axios) bypasses Apple's Network framework, so macOS never detects local network access
- This was masked in Move Everything Installer because developer machines had pre-existing LNP grants from unsigned local builds. The Schwung rename created a new bundle ID with no inherited grants, exposing it
- Anyone installing the distributed app on a fresh Mac (no prior local builds) would hit this

## Changes

- Use Electron's `net` module (Chromium's network stack) for HTTP device validation on macOS — this properly integrates with macOS LNP and triggers the permission prompt
- Add DNS resolution fallbacks for macOS (`dns.lookup` → `dscacheutil` → `dns-sd`), matching the existing Windows multi-method pattern
- Surface actual connection error codes instead of generic "Not a valid Move device"
- Show macOS LNP guidance in the UI when connection fails

## Test plan

- [x] Built unsigned local app, disabled Move Everything Installer LNP, launched from Finder — LNP prompt appeared, device connected
- [ ] Verify on a fresh Mac with no prior LNP grants
- [ ] Verify Windows/Linux behavior unchanged (Electron net only used on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)